### PR TITLE
Add and use __isBrowser global variable before accessing browser objects

### DIFF
--- a/app/components/activate.js
+++ b/app/components/activate.js
@@ -14,7 +14,7 @@ class Activate extends React.Component {
       }
    }
    componentWillMount() {
-     document.title = "CloudBoost | Activate"
+     if(__isBrowser) document.title = "CloudBoost | Activate"
       if(this.props.location.query.code == undefined){
          this.props.history.pushState('login')
       } else {

--- a/app/components/appReActivate.js
+++ b/app/components/appReActivate.js
@@ -12,7 +12,7 @@ class Reset extends React.Component {
         }
     }
     componentDidMount() {
-        document.title = "CloudBoost | Activate"
+        if(__isBrowser) document.title = "CloudBoost | Activate"
         if (!__isDevelopment) {
             /****Tracking*********/
             mixpanel.track('Portal:Visited ForgotPassword Page', {"Visited": "Visited ForgotPassword page in portal!"});

--- a/app/components/changePassword.js
+++ b/app/components/changePassword.js
@@ -16,7 +16,7 @@ class ChangePassword extends React.Component {
       }
    }
    componentWillMount() {
-     document.title = "CloudBoost | Change Password"
+     if(__isBrowser) document.title = "CloudBoost | Change Password"
       if(this.props.location.query.code == undefined){
          this.props.history.pushState('login')
       } else {

--- a/app/components/login.js
+++ b/app/components/login.js
@@ -19,7 +19,7 @@ class Login extends React.Component {
         }
     }
     componentDidMount() {
-        document.title = "CloudBoost | Login"
+        if(__isBrowser) document.title = "CloudBoost | Login"
         if (!__isDevelopment) {
             /****Tracking*********/
             mixpanel.track('Portal:Visited LogIn Page', {"Visited": "Visited Log In page in portal!"});

--- a/app/components/newServer.js
+++ b/app/components/newServer.js
@@ -17,7 +17,7 @@ class NewServer extends React.Component {
       }
    }
    componentWillMount() {
-     document.title = "CloudBoost | NewServer"
+     if(__isBrowser) document.title = "CloudBoost | NewServer"
       axios.get(USER_SERVICE_URL+'/server/isNewServer').then((res)=>{
          if(!res.data){
             window.location.href = '/#/login'

--- a/app/components/register.js
+++ b/app/components/register.js
@@ -23,7 +23,7 @@ class Register extends React.Component {
       }
    }
    componentDidMount(){
-     document.title = "CloudBoost | SignUp"
+     if(__isBrowser) document.title = "CloudBoost | SignUp"
       if(!__isDevelopment){
           /****Tracking*********/          
            mixpanel.track('Portal:Visited SignUp Page', { "Visited": "Visited Sign Up page in portal!"});

--- a/app/components/reset.js
+++ b/app/components/reset.js
@@ -14,7 +14,7 @@ class Reset extends React.Component {
         }
     }
     componentDidMount() {
-        document.title = "CloudBoost | Reset"
+        if(__isBrowser) document.title = "CloudBoost | Reset"
         if (!__isDevelopment) {
             /****Tracking*********/
             mixpanel.track('Portal:Visited ForgotPassword Page', {"Visited": "Visited ForgotPassword page in portal!"});

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ app.use(express.static(path.join(__dirname, 'app')));
 global.navigator = { navigator: 'all' };
 global.__isDevelopment = process.env["CLOUDBOOST_DEVELOPMENT"] || false
 global.__isHosted = process.env["CLOUDBOOST_HOSTED"] || false
+global.__isBrowser = false;
 if(__isHosted){
 	global.USER_SERVICE_URL = "https://service.cloudboost.io"
 	global.SERVER_DOMAIN = "cloudboost.io"
@@ -44,6 +45,7 @@ app.get('/app/key.js',function(req,res){
 		/***************************************************Connecting URLs*********************************************************/
 		content+= "var __isDevelopment = "+(process.env["CLOUDBOOST_DEVELOPMENT"] || "false")+";\n";
 		content+= "var __isHosted = "+(process.env["CLOUDBOOST_HOSTED"] || "false")+";\n";
+		content+= "var __isBrowser = typeof document !== 'undefined';\n";
 		content+= "var USER_SERVICE_URL = null,\n";
 		content+= "SERVER_URL = null,\n";
 		content+= "DASHBOARD_URL = null,\n";


### PR DESCRIPTION
Tested locally with `docker-compose`, using local build context for `cloudboost-accounts`, can now get through to app creation and management and server no longer throws. See screenshot below.

<img width="716" alt="screen shot 2017-03-09 at 11 32 34" src="https://cloud.githubusercontent.com/assets/1815885/23764831/21d398b4-04bc-11e7-9382-83394704b95a.png">
